### PR TITLE
Add information section skeleton

### DIFF
--- a/src/Restroom/RestroomDiscussion.js
+++ b/src/Restroom/RestroomDiscussion.js
@@ -1,20 +1,20 @@
-import React, { Component } from "react";
+import React, {Component} from "react";
 import axios from "axios";
 import RestroomCommentChain from "./RestroomCommentChain";
-import { Card, CardSubtitle, CardTitle, CardBody } from "reactstrap";
+import {Card, CardTitle, CardBody} from "reactstrap";
 
 export default class RestroomDiscussion extends Component {
   constructor(props) {
     super(props);
-    this.state = { comments: [] };
+    this.state = {comments: []};
   }
 
   componentDidMount = () => {
     axios
       .get("/restrooms/comments/" + this.props.id + "/none")
-      .then((response) => {
+      .then(response => {
         this.setState({
-          comments: response.data,
+          comments: response.data
         });
       });
   };
@@ -24,7 +24,7 @@ export default class RestroomDiscussion extends Component {
       <Card>
         <CardBody>
           <CardTitle tag="h5">Discussion Time.</CardTitle>
-          {this.state.comments.map((comment) => (
+          {this.state.comments.map(comment => (
             <RestroomCommentChain
               key={comment._id}
               id={comment._id}

--- a/src/Restroom/RestroomInformation.js
+++ b/src/Restroom/RestroomInformation.js
@@ -1,13 +1,35 @@
-import React, {Component} from 'react';
-import { Badge } from 'reactstrap';
+import React, {Component} from "react";
+import {Container, Col, Row} from "reactstrap";
+
+// components
+import Info from "../components/Info";
+
+// TODO: connect to the backend. Either pass in through props or make the call here.
+var fields = [
+  "3 stalls",
+  "wheelchair accessible",
+  "2 hand dryers",
+  "2 soap dispensers",
+  "3 sinks",
+  "mirror available"
+];
 
 export default class RestroomInformation extends Component {
   render() {
-    return(
-      <>
-        {this.props.handicap ? <Badge color="primary m-2" pill>Handicap</Badge>:<></>}
-        {this.props.single_use ? <Badge color="primary m-2" pill>Single Use</Badge>:<></>}
-      </>
+    // two columns, with hardcoded parameters for now.
+    // TODO: using <p> is a little hacky, change it to real styling later
+    return (
+      <Container>
+        <p />
+        <Row xs="2">
+          {fields.map(info => (
+            <Col>
+              <Info info={info} />
+            </Col>
+          ))}
+        </Row>
+        <p />
+      </Container>
     );
   }
 }

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -1,0 +1,26 @@
+/**
+ * Info component - shows a small card of the icon + the information.
+ *
+ * props:
+ *      image [string] - icon image to display, there will be a const list to select icons.
+ *      info [string] - information string to display
+ *      width [string] - width of the icon, ex - "25px" or "10vw"
+ */
+
+import React from "react";
+// assets (images + styles)
+import poopEmojiImg from "../../assets/brownPoop.png";
+import {InfoContainer, IconImg, InfoString} from "./style";
+
+// TODO: refactor the src to not just be the poop emoji, introduce a dictionary to choose from
+export default function Info(props) {
+  return (
+    <InfoContainer>
+      <IconImg
+        src={props.image ? props.image : poopEmojiImg}
+        width={props.width}
+      />
+      <InfoString>{props.info}</InfoString>
+    </InfoContainer>
+  );
+}

--- a/src/components/Info/style.js
+++ b/src/components/Info/style.js
@@ -8,6 +8,7 @@ export const InfoContainer = styled.div`
 `;
 
 export const IconImg = styled.img`
+  height: ${props => props.width || "22px"};
   width: ${props => props.width || "22px"};
   float: left;
 `;

--- a/src/components/Info/style.js
+++ b/src/components/Info/style.js
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+// TODO: apply some better styling here.
+export const InfoContainer = styled.div`
+  display: flex;
+  margin: auto;
+  width: 200px;
+`;
+
+export const IconImg = styled.img`
+  width: ${props => props.width || "22px"};
+  float: left;
+`;
+
+export const InfoString = styled.div`
+  text-align: left;
+  margin-left: 20px;
+`;

--- a/src/components/Reply/index.js
+++ b/src/components/Reply/index.js
@@ -5,19 +5,19 @@
  *
  */
 
-import React, { useState } from "react";
-import { ReplyContainer } from "./style";
-import { LineContainer } from "../CommentThread/style";
+import React, {useState} from "react";
+import {ReplyContainer} from "./style";
+import {LineContainer} from "../CommentThread/style";
 
 // reply component -- used in CommentComponent
 export default function Reply() {
   const [reply, setReply] = useState("");
 
   // TODO: make post request to backend when comment is submitted, and rerender
-  const handleSubmit = (e) => {
-    if (e.key == "Enter"){
+  const handleSubmit = e => {
+    if (e.key === "Enter") {
       console.log("submitted");
-    } 
+    }
   };
 
   return (
@@ -25,8 +25,8 @@ export default function Reply() {
       <ReplyContainer
         placeholder="Reply"
         value={reply}
-        onChange={(e) => setReply(e.target.value)}
-        onKeyDown={(e) => handleSubmit(e)}
+        onChange={e => setReply(e.target.value)}
+        onKeyDown={e => handleSubmit(e)}
       />
     </LineContainer>
   );


### PR DESCRIPTION
create an information section skeleton. Uses poop image as the icon for now, and hardcoded information as it is not available in the backend yet.

TODOs:
- better styling for the images
- dictionary to choose the correct icon for the information
- refactor out hacky styling solutions (`<p />` for spacing)
- better styling for each card itself as well.